### PR TITLE
Fixes EnderMonitor missing GuiValue

### DIFF
--- a/src/main/java/mcjty/rftoolspower/modules/endergenic/blocks/EnderMonitorTileEntity.java
+++ b/src/main/java/mcjty/rftoolspower/modules/endergenic/blocks/EnderMonitorTileEntity.java
@@ -2,6 +2,7 @@ package mcjty.rftoolspower.modules.endergenic.blocks;
 
 import mcjty.lib.api.container.DefaultContainerProvider;
 import mcjty.lib.bindings.GuiValue;
+import mcjty.lib.bindings.Value;
 import mcjty.lib.blocks.LogicSlabBlock;
 import mcjty.lib.builder.BlockBuilder;
 import mcjty.lib.container.GenericContainer;
@@ -38,6 +39,11 @@ public class EnderMonitorTileEntity extends TickingTileEntity implements TickOrd
 
     private boolean needpulse = false;
 
+    @GuiValue
+    public static final Value<EnderMonitorTileEntity, String> VALUE_MODE =
+        Value.createEnum("mode", EnderMonitorMode.values(), EnderMonitorTileEntity::getMode, EnderMonitorTileEntity::setMode);
+
+    
     @Cap(type = CapType.CONTAINER)
     private static final Function<EnderMonitorTileEntity, MenuProvider> SCREEN_CAP = be -> new DefaultContainerProvider<GenericContainer>("Ender Monitor")
             .containerSupplier(empty(EndergenicModule.CONTAINER_ENDER_MONITOR, be))


### PR DESCRIPTION
I think this value was missed when porting to 1.20. I took the same way as it is done with RFUtils, so do not know if it is correct way, but it works.

Addresses #107